### PR TITLE
Fix a syntax error when attribute is "required"

### DIFF
--- a/resources/export.rb
+++ b/resources/export.rb
@@ -25,7 +25,7 @@ end
 actions :create
 
 attribute :directory, :name_attribute => true
-attribute :network, :required
+attribute :network, :required => true
 attribute :writeable, :default => false, :kind_of => [TrueClass, FalseClass]
 attribute :sync, :default => true, :kind_of => [TrueClass, FalseClass]
 attribute :options, :default => ['root_squash'], :kind_of => Array


### PR DESCRIPTION
Error found with chef client 12.5.1
